### PR TITLE
Update image to circleci/ruby:2.6.6-node-browsers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-       - image: circleci/ruby:2.6.6-node-browsers
+       - image: circleci/ruby:2.6.6-node-browsers-legacy
          environment:
            - RAILS_ENV=test
            - RACK_ENV=test

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 > authentication across the [Turing School](https://github.com/turingschool)
 > community.
 
+
 ## Table of Contents
 - [Onboarding Tips](#onboarding)
   - [Heroku](#heroku)


### PR DESCRIPTION
To enable usage of PhantomJS in CI process (only included in `-legacy` images)