### PR TITLE
Change all instances of turing.io to turing.edu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ RUN bundle install --without test --binstubs --jobs 3
 
 COPY . .
 
-LABEL maintainer="Turing Engineering <contact@turing.io>"
+LABEL maintainer="Turing Engineering <contact@turing.edu>"
 
 CMD rm -f tmp/pids/server.pid && bin/rails server puma -p $PORT -b 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@
 
 ## [Onboarding tips](#onboarding)
 ### [Heroku](#heroku)
-* staging: census-app-staging and login-staging.turing.io
-* production: turing-census and login.turing.io
+* staging: census-app-staging and login-staging.turing.edu
+* production: turing-census and login.turing.edu
 * Other teams will use the staging app for their staging environment. Switching
   between environments requires configuring the oauth gem oauth endpoint.
   Install the gem via:

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: '"Turing School" <accounts@turing.io>'
+  default from: '"Turing School" <accounts@turing.edu>'
   layout 'mailer'
 end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -5,8 +5,8 @@ class InvitationMailer < ApplicationMailer
     enroll_elligible = invitation.enroll_elligible? && !is_resend
 
     mail(
-      bcc: ['jeff@turing.io', 'erin@turing.io'],
-      from: '"Turing School" <admissions@turing.io>',
+      bcc: ['jeff@turing.edu', 'erin@turing.edu'],
+      from: '"Turing School" <admissions@turing.edu>',
       subject: enroll_elligible ? "Welcome to Turing, #{@salutation_name}" : "Welcome to Turing",
       template_name: enroll_elligible ? "invite_with_enroll" : "invite",
       to: invitation.email

--- a/app/views/invitation_mailer/invite_with_enroll.html.erb
+++ b/app/views/invitation_mailer/invite_with_enroll.html.erb
@@ -3,10 +3,10 @@
     <%= "Hi #{@salutation_name}," %>
   </p>
   <p>
-    Congratulations and welcome! <strong>We are happy to inform you that you have been conditionally accepted to the Turing School of Software & Design.</strong> To join us officially, you will need to successfully complete Mod 0 - learn more <%= link_to("here", "https://mod0.turing.io/") %>.
+    Congratulations and welcome! <strong>We are happy to inform you that you have been conditionally accepted to the Turing School of Software & Design.</strong> To join us officially, you will need to successfully complete Mod 0 - learn more <%= link_to("here", "https://mod0.turing.edu/") %>.
   </p>
   <p>
-    You are about to embark upon an exciting, challenging, and life-changing experience that will be one of the hardest, best things you've ever done. Turing is hard, but it is worth it. Read some <%= link_to("alumni stories", "https://writing.turing.io/tag/alumni/") %> to learn more. Today, we're inviting you to join our community and enroll!
+    You are about to embark upon an exciting, challenging, and life-changing experience that will be one of the hardest, best things you've ever done. Turing is hard, but it is worth it. Read some <%= link_to("alumni stories", "https://writing.turing.edu/tag/alumni/") %> to learn more. Today, we're inviting you to join our community and enroll!
   </p>
   <p>
     <strong>Your next steps:</strong>
@@ -16,7 +16,7 @@
       <strong>Follow <%= link_to("this link", @url) %></strong> to create an account with Census, the Turing School of Software & Design's identity management application.
     </li>
     <li>
-      <strong>Visit <%= link_to("enroll.turing.io", "https://enroll.turing.io/") %></strong> to pay your deposit, choose a Mod 0, and choose a cohort. We recommend you do this ASAP, as cohorts fill up quickly. 
+      <strong>Visit <%= link_to("enroll.turing.edu", "https://enroll.turing.edu/") %></strong> to pay your deposit, choose a Mod 0, and choose a cohort. We recommend you do this ASAP, as cohorts fill up quickly.
     </li>
   </ol>
   <p>We invite you to explore the following financing options available to our students:</p>
@@ -26,15 +26,15 @@
     <li><%= link_to("Climb", "https://climbcredit.com/apply/turing") %></li>
   </ul>
   <p>
-    These options make it possible for you to start at Turing for as little as $1,200 up front and finance the rest. We have a dedicated support team to help you make the right financial decision. If you have questions about financing, please contact Darren at <%= mail_to("darren@turing.io") %>.
+    These options make it possible for you to start at Turing for as little as $1,200 up front and finance the rest. We have a dedicated support team to help you make the right financial decision. If you have questions about financing, please contact Darren at <%= mail_to("darren@turing.edu") %>.
   </p>
   <p>
-    If you have any questions about enrollment, please contact Erin at <%= mail_to("erin@turing.io") %> or by replying to this email.
+    If you have any questions about enrollment, please contact Erin at <%= mail_to("erin@turing.edu") %> or by replying to this email.
   </p>
   <p>Congrats again!</p>
   <p>
     The Turing Team
     <br />
-    Read more at <%= link_to("Turing Perspectives", "https://writing.turing.io/") %>
+    Read more at <%= link_to("Turing Perspectives", "https://writing.turing.edu/") %>
   </p>
 </div>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -8,27 +8,27 @@
     <title>Turing Email</title>
     <style>
       body *{font-family: 'Open Sans', Arial, sans-serif !important; color: #3c4040; }
-      
+
       div, p, a, li, td { -webkit-text-size-adjust:none; }
-      
+
       *{-webkit-font-smoothing: antialiased;-moz-osx-font-smoothing: grayscale;}
       td{word-break: break-word;}
       a{word-break: break-word; text-decoration: none; color: inherit; color: #00c2d3;}
-      
+
       body .ReadMsgBody
       {width: 100%; background-color: #ffffff;}
       body .ExternalClass
       {width: 100%; background-color: #ffffff;}
       body{width: 100%; height: 100%; background-color: #ffffff; margin:0; padding:0; -webkit-font-smoothing: antialiased; color: #3c4040;}
       html{ background-color:#ffffff; width: 100%;}
-      
+
       body p {padding: 0!important; margin-top: 0!important; margin-right: 0!important; margin-bottom: 20px !important; margin-left: 0!important; }
       body img {user-drag: none; -moz-user-select: none; -webkit-user-drag: none;}
       body a.rotator img {-webkit-transition: all 1s ease-in-out;-moz-transition: all 1s ease-in-out; -o-transition: all 1s ease-in-out; -ms-transition: all 1s ease-in-out; }
       body a.rotator img:hover { -webkit-transform: rotate(360deg); -moz-transform: rotate(360deg); -o-transform: rotate(360deg);-ms-transform: rotate(360deg); }
       body .hover:hover {opacity:0.85;filter:alpha(opacity=85);}
       body .jump:hover {opacity:0.75; filter:alpha(opacity=75); padding-top: 10px!important;}
-      
+
       body .logo img {width: 140px; height: auto;}
       body .image110 img {width: 110px; height: auto;}
       body .image280 img {width: 280px; height: auto;}
@@ -179,7 +179,7 @@
                                             <tbody>
                                               <tr>
                                                 <td class='fullCenter' style="text-align: left; font-size: 14px; color: #ffffff; font-family: Helvetica, Arial, sans-serif, 'Open Sans'; line-height: 22px; vertical-align: top; font-weight: 700;" width='420'>
-                                                  <a href='mailto:contact@turing.io' style='text-decoration: none; color: #ffffff;' target='_blank'>contact@turing.io</a>
+                                                  <a href='mailto:contact@turing.edu' style='text-decoration: none; color: #ffffff;' target='_blank'>contact@turing.edu</a>
                                                 </td>
                                               </tr>
                                             </tbody>
@@ -199,7 +199,7 @@
                                       </tr>
                                       <tr>
                                         <td align='center' class='fullCenter' style="text-align: left; font-size: 13px; color: #00c2d3; font-family: Helvetica, Arial, sans-serif, 'Open Sans'; line-height: 22px; vertical-align: top; font-weight: 400;" width='100%'>
-                                          <a href='&lt;?php echo $base_root . base_path(); ?&gt;' style='color: #00c2d3; text-decoration: none;' target='_blank'>turing.io</a>
+                                          <a href='&lt;?php echo $base_root . base_path(); ?&gt;' style='color: #00c2d3; text-decoration: none;' target='_blank'>turing.edu</a>
                                         </td>
                                       </tr>
                                     </tbody>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'accounts@turing.io'
+  config.mailer_sender = 'accounts@turing.edu'
 
   # Configure the class responsible to send e-mails.
   config.mailer = 'ConfirmationMailer'


### PR DESCRIPTION
Changes all turing.io instances to turing.edu 

https://3.basecamp.com/3494409/buckets/21005940/todos/3662961778

I have already update staging and production to host from:
login-staging.turing.edu
login.turing.edu 

With the .edu switch over, we should send emails from these accounts as well as begin to direct link to other app rather than relying on redirects.