### PR TITLE
Update copy for invite_with_enroll email (no more Enroll)

### DIFF
--- a/app/views/invitation_mailer/invite_with_enroll.html.erb
+++ b/app/views/invitation_mailer/invite_with_enroll.html.erb
@@ -3,7 +3,7 @@
     <%= "Hi #{@salutation_name}," %>
   </p>
   <p>
-    Congratulations and welcome! <strong>We are happy to inform you that you have been conditionally accepted to the Turing School of Software & Design.</strong> To join us officially, you will need to successfully complete Mod 0 - learn more <%= link_to("here", "https://mod0.turing.edu/") %>.
+    Congratulations and welcome! <strong>We are happy to inform you that you have been conditionally accepted to the Turing School of Software & Design.</strong> To join us officially, you will need to complete your enrollment (see steps below) and successfully complete Mod 0 - learn more <%= link_to("here", "https://mod0.turing.edu/") %>.
   </p>
   <p>
     You are about to embark upon an exciting, challenging, and life-changing experience that will be one of the hardest, best things you've ever done. Turing is hard, but it is worth it. Read some <%= link_to("alumni stories", "https://writing.turing.edu/tag/alumni/") %> to learn more. Today, we're inviting you to join our community and enroll!
@@ -13,10 +13,10 @@
   </p>
   <ol>
     <li>
-      <strong>Follow <%= link_to("this link", @url) %></strong> to create an account with Census, the Turing School of Software & Design's identity management application.
+      <strong>Visit the <%= link_to("prep site", "https://turing.edu/prep") %></strong> and complete the steps outlined to finalize your enrollment.
     </li>
     <li>
-      <strong>Visit <%= link_to("enroll.turing.edu", "https://enroll.turing.edu/") %></strong> to pay your deposit, choose a Mod 0, and choose a cohort. We recommend you do this ASAP, as cohorts fill up quickly.
+      <strong>Follow <%= link_to("this link", @url) %></strong> to create an account with Census, the Turing School of Software & Design's identity management application.
     </li>
   </ol>
   <p>We invite you to explore the following financing options available to our students:</p>
@@ -26,7 +26,7 @@
     <li><%= link_to("Climb", "https://climbcredit.com/apply/turing") %></li>
   </ul>
   <p>
-    These options make it possible for you to start at Turing for as little as $1,200 up front and finance the rest. We have a dedicated support team to help you make the right financial decision. If you have questions about financing, please contact Darren at <%= mail_to("darren@turing.edu") %>.
+    These options make it possible for you to start at Turing for as little as $1,200 up front and finance the rest. We have a dedicated support team to help you make the right financial decision. If you have questions about financing, please contact Tamika at <%= mail_to("tamika@turing.edu") %>.
   </p>
   <p>
     If you have any questions about enrollment, please contact Erin at <%= mail_to("erin@turing.edu") %> or by replying to this email.
@@ -35,6 +35,6 @@
   <p>
     The Turing Team
     <br />
-    Read more at <%= link_to("Turing Perspectives", "https://writing.turing.edu/") %>
+    Read more at <%= link_to("Turing Blog", "https://writing.turing.edu/") %>
   </p>
 </div>

--- a/app/views/invitation_mailer/invite_with_enroll.html.erb
+++ b/app/views/invitation_mailer/invite_with_enroll.html.erb
@@ -13,7 +13,7 @@
   </p>
   <ol>
     <li>
-      <strong>Visit the <%= link_to("prep site", "https://turing.edu/prep") %></strong> and complete the steps outlined to finalize your enrollment.
+      <strong>Create your user account</strong> in our Student Information System, Populi (you will receive a separate email to log in). Once you log in, follow all the steps outlined in Turing's <%= link_to("prep site", "https://turing.edu/prep") %>.
     </li>
     <li>
       <strong>Follow <%= link_to("this link", @url) %></strong> to create an account with Census, the Turing School of Software & Design's identity management application.

--- a/app/views/invitation_mailer/invite_with_enroll.html.erb
+++ b/app/views/invitation_mailer/invite_with_enroll.html.erb
@@ -26,7 +26,7 @@
     <li><%= link_to("Climb", "https://climbcredit.com/apply/turing") %></li>
   </ul>
   <p>
-    These options make it possible for you to start at Turing for as little as $1,200 up front and finance the rest. We have a dedicated support team to help you make the right financial decision. If you have questions about financing, please contact Tamika at <%= mail_to("tamika@turing.edu") %>.
+    These options make it possible for you to enroll at Turing for as little as $1,200 up front and finance the rest. We have a dedicated support team to help you make the right financial decision. If you have questions about financing, please contact Tamika at <%= mail_to("tamika@turing.edu") %>.
   </p>
   <p>
     If you have any questions about enrollment, please contact Erin at <%= mail_to("erin@turing.edu") %> or by replying to this email.


### PR DESCRIPTION
- Direct applicants to the Prep site, not Enroll (prep site will include
  instructions for using Populi)
- Replace Darren's info w/ Tamika
- Rename "Perspectives" to "Blog" (to match the marketing site)

Addresses [Post-acceptance "Invite" email updated](https://3.basecamp.com/3494409/buckets/19998684/todos/4034936815)

**NEW**
<img width="832" alt="new" src="https://user-images.githubusercontent.com/709100/129603317-9dd40824-b148-4ab0-81b8-98b366543aac.png">

**OLD**
<img width="832" alt="old" src="https://user-images.githubusercontent.com/709100/129603325-26b43181-3533-464a-a8c9-6f20d0151705.png">
